### PR TITLE
Fetch latest opportunities from Grants.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ pip install -r requirements.txt
 python src/pipeline.py
 ```
 
+The pipeline will attempt to download the latest funding opportunities from
+the Grants.gov Search API. If the download fails (e.g., no network access),
+it will fall back to the previously cached `data/master.csv` file.
+
 ## Outputs
 - outputs/CleanTable.csv
 - outputs/Dirty.csv
 - outputs/OutOfScope.csv
 - outputs/Master_Scored.csv
-- outputs/EQORE_Deck.pptx
+- outputs/EQORE_Deck.pptx (top 50 opportunities)
 # funding-pipline

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.32.5
 six==1.17.0
 tzdata==2025.2
 urllib3==2.5.0
+python-pptx==0.6.23

--- a/src/build_deck.py
+++ b/src/build_deck.py
@@ -1,6 +1,20 @@
 from pptx import Presentation
 
-def build_deck(df, out_path):
+
+def build_deck(df, out_path, max_results: int = 50):
+    """Build a PowerPoint deck of the top funding opportunities.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Scored funding opportunities. Expected to contain ``Rank``, ``Grant Name``
+        and ``Weighted Score`` columns.
+    out_path : str
+        Path where the deck should be saved.
+    max_results : int, optional
+        Maximum number of opportunities to include. Defaults to 50.
+    """
+
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[0])
     slide.shapes.title.text = "EQORE Funding Deck"
@@ -8,7 +22,14 @@ def build_deck(df, out_path):
 
     slide = prs.slides.add_slide(prs.slide_layouts[1])
     slide.shapes.title.text = "Top Opportunities"
-    text = "\n".join([f"{row['Rank']}. {row['Grant Name']} ({row['Weighted Score']})" for _, row in df.iterrows()])
+
+    top_df = df.head(max_results)
+    text = "\n".join(
+        [
+            f"{row['Rank']}. {row['Grant Name']} ({row['Weighted Score']})"
+            for _, row in top_df.iterrows()
+        ]
+    )
     slide.placeholders[1].text = text
 
     prs.save(out_path)

--- a/src/fetch_grants.py
+++ b/src/fetch_grants.py
@@ -1,0 +1,43 @@
+"""Utilities for downloading opportunity data from Grants.gov."""
+
+from __future__ import annotations
+
+import pandas as pd
+import requests
+
+DEFAULT_URL = "https://www.grants.gov/grantsws/rest/opportunities/search"
+
+
+def fetch_grants(max_results: int = 50, outfile: str = "data/master.csv") -> pd.DataFrame:
+    """Fetch funding opportunities from Grants.gov and save them to ``outfile``.
+
+    Parameters
+    ----------
+    max_results:
+        Maximum number of opportunity records to request from the API.
+    outfile:
+        CSV file path where the results will be written.
+
+    Returns
+    -------
+    DataFrame
+        The downloaded opportunity data.
+    """
+
+    params = {
+        "startRecordNum": 1,
+        "oppNumRecords": max_results,
+        "sortBy": "openDate",
+        "sortOrder": "desc",
+    }
+    headers = {"Accept": "application/json"}
+
+    response = requests.get(DEFAULT_URL, params=params, headers=headers, timeout=30)
+    response.raise_for_status()
+
+    data = response.json()
+    # The API returns a list of opportunities under the ``oppHits`` key.
+    opportunities = data.get("oppHits", [])
+    df = pd.DataFrame(opportunities)
+    df.to_csv(outfile, index=False)
+    return df

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,9 +1,23 @@
 import pandas as pd
 from src.triage_and_score import triage_and_score
 from src.build_deck import build_deck
+from src.fetch_grants import fetch_grants
 
 def main():
-    df = pd.read_csv("data/master.csv")
+    """Run the funding pipeline.
+
+    The pipeline first tries to download the latest opportunities from
+    Grants.gov. If the download fails (for example, due to missing
+    network access), it falls back to the previously cached
+    ``data/master.csv`` file.
+    """
+
+    try:
+        df = fetch_grants(max_results=50)
+    except Exception as exc:  # pragma: no cover - best effort fallback
+        print(f"Warning: could not fetch data from Grants.gov ({exc})")
+        df = pd.read_csv("data/master.csv")
+
     clean, dirty, oos = triage_and_score(df)
 
     clean.to_csv("outputs/CleanTable.csv", index=False)
@@ -11,7 +25,8 @@ def main():
     oos.to_csv("outputs/OutOfScope.csv", index=False)
     clean.to_csv("outputs/Master_Scored.csv", index=False)
 
-    build_deck(clean, "outputs/EQORE_Deck.pptx")
+    # Build a deck showing the top 50 opportunities
+    build_deck(clean, "outputs/EQORE_Deck.pptx", max_results=50)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- download opportunity data from the Grants.gov Search API and save to `data/master.csv`
- pipeline now fetches the latest opportunities before triaging, falling back to the cached CSV when the API request fails
- document the automatic download step in the README

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement python-pptx==0.6.23)*
- `python -m src.pipeline` *(failed: ModuleNotFoundError: No module named 'pptx')*

------
https://chatgpt.com/codex/tasks/task_e_68af1cd77a4c8332989f6c3c7c0edbef